### PR TITLE
Fix: closed mobile menu intercepting clicks

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -272,11 +272,17 @@ button {
     border-bottom: 1px solid var(--border);
     transform: translateY(-12px);
     opacity: 0;
-    transition: transform 0.25s ease, opacity 0.25s ease;
+    /* closed menu must not intercept taps — it stays in the DOM (display:flex)
+       for the open/close animation, so hide it from hit-testing explicitly */
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.25s ease, opacity 0.25s ease, visibility 0.25s ease;
 }
 .mobile-menu:not([hidden]) {
     transform: translateY(0);
     opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 .mobile-menu a {
     font-family: var(--font-pixel);


### PR DESCRIPTION
## Problem
On the live site, clicking near the top of a section (or the experience tabs) sometimes triggers a smooth-scroll jump to a random section — on both desktop and mobile.

## Cause
The mobile menu's base rule has `display: flex`, which overrides the `hidden` attribute. So even when 'closed', the menu stays in the DOM as a fixed, full-width, invisible overlay below the nav — and its nav links swallow clicks, scrolling you elsewhere.

## Fix
Make the closed menu non-interactive with `visibility: hidden` + `pointer-events: none` (open/close animation preserved). Verified with `elementFromPoint` across every section header at 390px and 1280px — clicks now land on the headers themselves, no overlay.

(This is the same fix that didn't make it into PR #3's merge; isolating it here so production gets fixed without waiting on the larger mobile-layout PR.)