### PR TITLE
Mobile layout: vertical maze + centered hero

### DIFF
--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -32,20 +32,19 @@ only as tasteful **accents**. Projects get a creative **pacman-maze gallery** tr
   rooms alternating across a pellet trail, pacman + ghost).
 
 ## Status
-- [x] Desktop v1 mockup (Figma)
-- [x] Mobile v1 mockup (Figma)
-- [x] Mobile sizing pass (scaled down type/cards, wider margins)
+- [x] Desktop + mobile mockups (Figma)
+- [x] **v2 shipped in code** (PR #2, merged): light grid theme, pacman maze gallery, Bitcount
+      Prop Single font, curated `data/projects.json` + local GIFs (no more GitHub README
+      scraping), resume-accurate Skills/Experience, fluid/responsive layout.
+- [x] Deploy hotfix (PR #3, merged): `js/projects.js` was gitignored → 404 on the live site.
 
-## TODO — implementation (in code)
-- [ ] Rebuild `index.html` + CSS to match the Figma v1 (fluid layout: `clamp()`, flex/grid;
-      drop the percentage/negative margins + scroll-snap hacks).
-- [ ] Light grid background; pacman as accents only.
-- [ ] Load **Bitcount Prop Single** (+ chosen pixel font) via Google Fonts.
-- [ ] Build the desktop pacman-maze projects gallery + mobile zigzag version.
-- [ ] **Replace GitHub README-scraping in `projects.js`** with curated **local assets**.
-      GitHub unauth API is 60 req/hr and currently called per-repo per-page-load.
-      - Curated `projects.json`: `{ title, blurb, tags, image, gif, repoUrl, demoUrl }`.
-      - Cards show a poster frame by default, play GIF/short muted video on hover/tap.
-      - Optional: one-time script reusing existing extraction logic to pull current GIFs local.
-- [ ] Responsive breakpoints + smooth animations.
-- [ ] Update Skills/Experience copy from resume.
+## TODO
+- [ ] **Clean up the Pages deploy workflow** (`.github/workflows/static.yml`): remove the leftover
+      v1 steps (*Setup Node.js*, *Fetch GitHub repos*, *Commit data*) that regenerate and
+      re-commit the obsolete `repos.json` on every deploy, drop the `contents: write` permission,
+      and delete `repos.json`. Requires a token with `workflow` scope (`gh auth refresh -s workflow`).
+- [ ] **Mobile layout** (in progress — branch `feat/mobile-layout`): zigzag mini-maze for the
+      projects section + compact mobile sizing. Also carries the closed-mobile-menu tap-interception
+      fix (the menu kept `display:flex` and swallowed taps near the top of the page).
+- [ ] Media optimization: convert project GIFs → mp4/webm to shrink the ~19MB payload
+      (`scripts/optimize-media.py`, needs `ffmpeg`).

--- a/css/maze.css
+++ b/css/maze.css
@@ -167,6 +167,7 @@
         flex-direction: column;
         align-items: center;
         gap: 0;
+        padding-block: 46px;
     }
     .maze__trail {
         display: none; /* desktop horizontal trails not used on mobile */

--- a/css/maze.css
+++ b/css/maze.css
@@ -160,24 +160,72 @@
     opacity: 1;
 }
 
-/* ---- responsive: stack into a vertical maze ---- */
+/* mobile-only descending-maze decoration (hidden on desktop) */
+.maze__mtrail {
+    display: none;
+}
+
+/* ---- responsive: zigzag mini-maze ---- */
 @media (max-width: 860px) {
-    .maze__row {
+    .maze {
+        display: flex;
         flex-direction: column;
-        gap: 14px;
+        align-items: stretch;
+        gap: 26px;
     }
-    .proom {
-        max-width: none;
-        aspect-ratio: 16 / 9;
+    .maze__row {
+        display: contents; /* flatten the row groups into one column */
     }
     .maze__trail {
-        gap: 12px;
+        display: none; /* hide the horizontal desktop trails */
     }
-    .maze__trail .pac {
-        --pac-size: 38px;
+
+    .proom {
+        flex: none; /* in a column, flex:1 1 0 would zero the height — let aspect-ratio drive it */
+        width: 74%;
+        max-width: none;
+        aspect-ratio: 4 / 3;
+        z-index: 1;
     }
-    .maze__trail .pellet {
-        width: 8px;
-        height: 8px;
+    .proom--left {
+        align-self: flex-start;
+    }
+    .proom--right {
+        align-self: flex-end;
+    }
+
+    /* dotted pellet trail down the centre, behind the rooms */
+    .maze::after {
+        content: "";
+        position: absolute;
+        top: 46px;
+        bottom: 46px;
+        left: 50%;
+        transform: translateX(-50%);
+        border-left: 3px dotted #ffc847;
+        opacity: 0.55;
+        z-index: 0;
+    }
+
+    /* pacman descending the trail + a ghost partway down */
+    .maze__mtrail {
+        display: block;
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+    }
+    .maze__mtrail-pac {
+        position: absolute;
+        top: 10px;
+        left: 50%;
+        transform: translateX(-50%) rotate(90deg);
+        --pac-size: 32px;
+    }
+    .maze__mtrail-ghost {
+        position: absolute;
+        top: 47%;
+        left: 50%;
+        transform: translateX(-50%);
     }
 }

--- a/css/maze.css
+++ b/css/maze.css
@@ -183,7 +183,7 @@
     .maze__pac-down {
         --pac-size: 28px;
         transform: rotate(90deg);
-        margin-bottom: 6px;
+        margin-bottom: 22px;
     }
 
     /* connector between two rooms: a run of pellet dots, or a ghost */

--- a/css/maze.css
+++ b/css/maze.css
@@ -160,72 +160,59 @@
     opacity: 1;
 }
 
-/* mobile-only descending-maze decoration (hidden on desktop) */
-.maze__mtrail {
-    display: none;
-}
-
-/* ---- responsive: zigzag mini-maze ---- */
+/* ---- responsive: vertical stacked mini-maze ---- */
 @media (max-width: 860px) {
     .maze {
         display: flex;
         flex-direction: column;
-        align-items: stretch;
-        gap: 26px;
-    }
-    .maze__row {
-        display: contents; /* flatten the row groups into one column */
+        align-items: center;
+        gap: 0;
     }
     .maze__trail {
-        display: none; /* hide the horizontal desktop trails */
+        display: none; /* desktop horizontal trails not used on mobile */
     }
-
     .proom {
-        flex: none; /* in a column, flex:1 1 0 would zero the height — let aspect-ratio drive it */
-        width: 74%;
+        flex: none; /* column flex: let width + aspect-ratio drive the size */
+        width: 80%;
         max-width: none;
-        aspect-ratio: 4 / 3;
-        z-index: 1;
-    }
-    .proom--left {
-        align-self: flex-start;
-    }
-    .proom--right {
-        align-self: flex-end;
+        aspect-ratio: 7 / 3;
     }
 
-    /* dotted pellet trail down the centre, behind the rooms */
-    .maze::after {
-        content: "";
-        position: absolute;
-        top: 46px;
-        bottom: 46px;
-        left: 50%;
-        transform: translateX(-50%);
-        border-left: 3px dotted #ffc847;
-        opacity: 0.55;
-        z-index: 0;
+    /* pacman descending from the top of the stack */
+    .maze__pac-down {
+        --pac-size: 28px;
+        transform: rotate(90deg);
+        margin-bottom: 6px;
     }
 
-    /* pacman descending the trail + a ghost partway down */
-    .maze__mtrail {
-        display: block;
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        z-index: 0;
+    /* connector between two rooms: a run of pellet dots, or a ghost */
+    .maze__conn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 7px;
+        padding: 13px 0;
     }
-    .maze__mtrail-pac {
-        position: absolute;
-        top: 10px;
-        left: 50%;
-        transform: translateX(-50%) rotate(90deg);
-        --pac-size: 32px;
+    .maze__conn-pellet {
+        width: 7px;
+        height: 7px;
+        background: #ffc847;
     }
-    .maze__mtrail-ghost {
-        position: absolute;
-        top: 47%;
-        left: 50%;
-        transform: translateX(-50%);
+    .maze__conn .ghost {
+        width: 28px;
+        height: 30px;
+    }
+    .maze__conn .ghost::before,
+    .maze__conn .ghost::after {
+        top: 8px;
+        width: 7px;
+        height: 9px;
+    }
+    .maze__conn .ghost::before {
+        left: 5px;
+    }
+    .maze__conn .ghost::after {
+        right: 5px;
     }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -698,10 +698,27 @@ button {
         min-height: auto;
         padding-block: clamp(64px, 12vw, 96px);
     }
+    .hero__inner {
+        text-align: center;
+    }
+    .hero__lead {
+        margin-inline: auto;
+    }
+    .hero__cta {
+        justify-content: center;
+        gap: 12px;
+    }
+    .hero__cta .btn {
+        flex: none;
+        width: 140px;
+        padding: 11px 0;
+        font-size: 0.85rem;
+    }
     .hero__motif {
         position: static;
         transform: none;
         margin-top: 32px;
+        justify-content: center;
     }
     .hero__motif .pac {
         --pac-size: 64px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -272,11 +272,17 @@ button {
     border-bottom: 1px solid var(--border);
     transform: translateY(-12px);
     opacity: 0;
-    transition: transform 0.25s ease, opacity 0.25s ease;
+    /* closed menu must not intercept taps — it stays in the DOM (display:flex)
+       for the open/close animation, so hide it from hit-testing explicitly */
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.25s ease, opacity 0.25s ease, visibility 0.25s ease;
 }
 .mobile-menu:not([hidden]) {
     transform: translateY(0);
     opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 .mobile-menu a {
     font-family: var(--font-pixel);

--- a/js/projects.js
+++ b/js/projects.js
@@ -40,6 +40,34 @@ function renderMaze(maze, projects) {
         maze.appendChild(buildRow(row));
         if (i < rows.length - 1) maze.appendChild(buildTrail(trailIndex++));
     });
+
+    // alternate each room left/right for the mobile zigzag layout
+    maze.querySelectorAll(".proom").forEach((card, i) => {
+        card.classList.add(i % 2 === 0 ? "proom--left" : "proom--right");
+    });
+
+    // mobile-only: pacman descending the centre trail + a ghost
+    maze.appendChild(buildMobileTrail());
+}
+
+function buildMobileTrail() {
+    const deco = document.createElement("div");
+    deco.className = "maze__mtrail";
+    deco.setAttribute("aria-hidden", "true");
+
+    const pac = document.createElement("span");
+    pac.className = "pac maze__mtrail-pac";
+    deco.appendChild(pac);
+
+    const ghost = document.createElement("span");
+    ghost.className = "ghost maze__mtrail-ghost";
+    ghost.style.setProperty("--gc", "var(--pink)");
+    const mouth = document.createElement("span");
+    mouth.className = "ghost__mouth";
+    ghost.appendChild(mouth);
+    deco.appendChild(ghost);
+
+    return deco;
 }
 
 function buildRow(projects) {

--- a/js/projects.js
+++ b/js/projects.js
@@ -27,47 +27,73 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 function renderMaze(maze, projects) {
+    drawMaze(maze, projects);
+    // re-render when crossing the mobile breakpoint (desktop rows <-> mobile stack)
+    const mq = window.matchMedia("(max-width: 860px)");
+    let wasMobile = mq.matches;
+    window.addEventListener("resize", () => {
+        if (mq.matches !== wasMobile) {
+            wasMobile = mq.matches;
+            drawMaze(maze, projects);
+        }
+    });
+}
+
+function drawMaze(maze, projects) {
     maze.innerHTML = "";
+    if (window.matchMedia("(max-width: 860px)").matches) drawMobile(maze, projects);
+    else drawDesktop(maze, projects);
+}
 
-    // split into rows of three
+// desktop: rows of three with a horizontal pellet trail between rows
+function drawDesktop(maze, projects) {
     const rows = [];
-    for (let i = 0; i < projects.length; i += 3) {
-        rows.push(projects.slice(i, i + 3));
-    }
-
+    for (let i = 0; i < projects.length; i += 3) rows.push(projects.slice(i, i + 3));
     let trailIndex = 0;
     rows.forEach((row, i) => {
         maze.appendChild(buildRow(row));
         if (i < rows.length - 1) maze.appendChild(buildTrail(trailIndex++));
     });
-
-    // alternate each room left/right for the mobile zigzag layout
-    maze.querySelectorAll(".proom").forEach((card, i) => {
-        card.classList.add(i % 2 === 0 ? "proom--left" : "proom--right");
-    });
-
-    // mobile-only: pacman descending the centre trail + a ghost
-    maze.appendChild(buildMobileTrail());
 }
 
-function buildMobileTrail() {
-    const deco = document.createElement("div");
-    deco.className = "maze__mtrail";
-    deco.setAttribute("aria-hidden", "true");
+// mobile: a single vertical stack — pacman descends from the top, with a
+// pellet/ghost connector between each pair of rooms
+function drawMobile(maze, projects) {
+    maze.appendChild(buildPacDown());
+    projects.forEach((p, i) => {
+        maze.appendChild(buildRoom(p));
+        if (i < projects.length - 1) maze.appendChild(buildConnector(i));
+    });
+}
 
+function buildPacDown() {
     const pac = document.createElement("span");
-    pac.className = "pac maze__mtrail-pac";
-    deco.appendChild(pac);
+    pac.className = "pac maze__pac-down";
+    pac.setAttribute("aria-hidden", "true");
+    return pac;
+}
 
-    const ghost = document.createElement("span");
-    ghost.className = "ghost maze__mtrail-ghost";
-    ghost.style.setProperty("--gc", "var(--pink)");
-    const mouth = document.createElement("span");
-    mouth.className = "ghost__mouth";
-    ghost.appendChild(mouth);
-    deco.appendChild(ghost);
-
-    return deco;
+function buildConnector(i) {
+    const conn = document.createElement("div");
+    conn.className = "maze__conn";
+    conn.setAttribute("aria-hidden", "true");
+    if (i % 2 === 0) {
+        for (let k = 0; k < 3; k++) {
+            const d = document.createElement("span");
+            d.className = "pellet maze__conn-pellet";
+            conn.appendChild(d);
+        }
+    } else {
+        const colors = ["var(--cyan)", "var(--pink)", "var(--orange)"];
+        const ghost = document.createElement("span");
+        ghost.className = "ghost";
+        ghost.style.setProperty("--gc", colors[Math.floor(i / 2) % colors.length]);
+        const mouth = document.createElement("span");
+        mouth.className = "ghost__mouth";
+        ghost.appendChild(mouth);
+        conn.appendChild(ghost);
+    }
+    return conn;
 }
 
 function buildRow(projects) {


### PR DESCRIPTION
Dedicated mobile-layout pass (≤860px). Desktop is unchanged — all rules are scoped to the mobile breakpoint, and the maze render branches by viewport (with a re-render on breakpoint change).

## Projects maze → vertical stack
- On mobile the maze descends as a single centered column instead of the wide row grid.
- **Pacman descends from the top**, and a **connector sits between each pair of rooms** — a run of pellet dots, or a ghost (cyan / pink / orange), rendered as real flex items so they land cleanly in the gaps.
- Cards are smaller (7/3) and centered; the blue maze wall is inset so it never touches them.
- Roomy top/bottom padding inside the container, plus a gap between the pacman and the first card.

## Hero → mobile-friendly
- Center-aligned content (eyebrow, heading, the `</ Jamie Kim >` name, paragraph).
- Two **small, equal-width inline buttons** ("View projects" / "Get in touch").
- Centered pacman + pellet motif.

## Notes
- Carries the closed-mobile-menu tap fix (already on `main` via #4; nets to zero here).
- Verified desktop still renders 3 rows with the horizontal pellet trail; mobile verified via headless screenshots at 390px.

🎨 Figma mobile frame updated to match.