### PR TITLE
Add About section: arcade-cabinet player profile

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -1,0 +1,230 @@
+/* ============================================================
+   About — arcade cabinet (desktop only for now)
+   Screen "powers on" after a coin-insert + pacman crossing.
+   ============================================================ */
+
+.cabinet {
+    --screen: #23283f;
+    --screen-text: #ffffff;
+    --screen-soft: #9aa3b5;
+    --screen-chip: #2b3148;
+    --bezel: #0d0f18;
+    --deck: #d9dce6;
+    --ctrl: #212433;
+
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    padding: 26px;
+    border-radius: 32px;
+    background: #e8eaf1;
+    border: 1px solid #d3d7e0;
+    box-shadow: var(--shadow-lg);
+}
+
+/* lit marquee header */
+.cabinet__marquee {
+    text-align: center;
+    font-family: var(--font-pixel);
+    font-size: 1.05rem;
+    letter-spacing: 2px;
+    color: #fff;
+    background: #6f7589;
+    padding: 13px;
+    border-radius: 12px;
+}
+
+/* monitor bezel + screen */
+.cabinet__monitor {
+    background: var(--bezel);
+    border-radius: 22px;
+    padding: 8px;
+}
+.cabinet__screen {
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+    background: var(--screen);
+    padding: 36px 42px;
+    min-height: 430px;
+}
+
+/* HUD (always on) */
+.screen__hud {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-pixel);
+    letter-spacing: 1px;
+    margin-bottom: 26px;
+}
+.screen__hud-l { color: var(--yellow); font-size: 0.95rem; }
+.screen__hud-r { color: var(--screen-soft); font-size: 0.95rem; }
+
+/* ---- screen content (revealed) ---- */
+.screen__body { display: flex; gap: 48px; align-items: flex-start; }
+.about__left { flex: 0 0 320px; }
+.about__right { flex: 1; min-width: 0; }
+
+.about__avatar { --pac-size: 90px; display: block; margin-bottom: 16px; }
+.about__name { font-family: var(--font-pixel); font-size: 1.8rem; color: var(--screen-text); margin: 0 0 12px; }
+.about__blurb { font-size: 0.92rem; line-height: 1.65; color: var(--screen-soft); margin: 0 0 16px; }
+
+.about__socials { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.about__socials a {
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 7px 13px 7px 11px; border-radius: 999px;
+    background: var(--screen-chip); color: var(--screen-text);
+    font-size: 0.8rem; font-weight: 500;
+    transition: transform 0.15s ease, background 0.2s ease;
+}
+.about__socials a::before { content: ""; width: 9px; height: 9px; border-radius: 50%; background: var(--c, var(--yellow)); }
+.about__socials a:hover { transform: translateY(-2px); background: #333b56; }
+
+.about__label { font-family: var(--font-pixel); font-size: 0.85rem; letter-spacing: 1px; color: var(--yellow); margin: 0 0 12px; }
+.about__right .about__label:not(:first-child) { margin-top: 22px; }
+
+.about__chase { list-style: none; margin: 0; padding: 0; display: grid; grid-template-columns: 1fr 1fr; gap: 12px 24px; }
+.about__chase li { display: flex; align-items: center; gap: 10px; color: var(--screen-text); font-size: 0.95rem; }
+.about__chase .ghost { width: 24px; height: 26px; flex: none; }
+.about__chase .ghost::before, .about__chase .ghost::after { top: 8px; width: 6px; height: 8px; }
+.about__chase .ghost::before { left: 5px; }
+.about__chase .ghost::after { right: 5px; }
+
+.about__scores { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.about__scores li { background: var(--screen-chip); color: var(--screen-soft); font-size: 0.8rem; font-weight: 500; padding: 7px 12px; border-radius: 999px; }
+
+.about__creative {
+    margin-top: 22px; display: flex; align-items: center; gap: 14px;
+    padding: 14px 18px; border-radius: 14px;
+    background: #1f2438; border: 1.5px solid rgba(255, 95, 162, 0.6);
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+.about__creative:hover { transform: translateY(-2px); box-shadow: 0 8px 22px rgba(255, 95, 162, 0.25); }
+.about__creative-icon { width: 34px; height: 34px; border-radius: 50%; flex: none; background: var(--pink); }
+.about__creative-text { display: flex; flex-direction: column; gap: 2px; }
+.about__creative-title { font-family: var(--font-pixel); font-size: 0.95rem; color: var(--screen-text); }
+.about__creative-sub { font-size: 0.8rem; color: var(--screen-soft); }
+
+/* ---- loading overlay (shown only while "armed") ---- */
+.screen__loading {
+    position: absolute;
+    inset: 0;
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+}
+.screen__track {
+    position: absolute;
+    top: 46%;
+    left: 9%;
+    right: 9%;
+    height: 0;
+}
+.screen__pellet {
+    position: absolute;
+    top: 0;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #ffc847;
+    transform: translate(-50%, -50%);
+}
+.screen__crosser {
+    --pac-size: 30px;
+    position: absolute;
+    top: 0;
+    left: 5%;
+    z-index: 2;
+    transform: translate(-50%, -50%);
+}
+.screen__prompt {
+    margin: 0;
+    margin-top: 60px;
+    font-family: var(--font-pixel);
+    font-size: 1.25rem;
+    letter-spacing: 2px;
+    color: var(--yellow);
+}
+
+/* ---- control deck ---- */
+.cabinet__deck {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--deck);
+    border-radius: 18px;
+    padding: 22px 48px;
+}
+.deck__joystick { position: relative; width: 76px; height: 92px; flex: none; }
+.deck__joystick .deck__base { position: absolute; bottom: 0; left: 12px; width: 52px; height: 52px; border-radius: 50%; background: var(--ctrl); }
+.deck__joystick .deck__stem { position: absolute; bottom: 26px; left: 32px; width: 12px; height: 48px; border-radius: 6px; background: var(--ctrl); transform-origin: 50% 100%; transform: rotate(22deg); }
+.deck__joystick .deck__ball { position: absolute; top: 6px; left: 41px; width: 30px; height: 30px; border-radius: 50%; background: var(--red); }
+/* buttons centered in the deck regardless of joystick/coin width */
+.deck__buttons { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); display: flex; gap: 20px; }
+.deck__buttons i { width: 40px; height: 40px; border-radius: 50%; background: var(--b, var(--yellow)); border: 3px solid #666e80; }
+.deck__coin { position: relative; display: flex; align-items: center; gap: 10px; }
+.deck__slot { position: relative; z-index: 1; width: 12px; height: 46px; border-radius: 6px; background: var(--ctrl); }
+/* coin appears only during the insert animation, sliding left-to-right into the slot;
+   the slot (z-index 1) overlays whatever has gone in, the part still outside stays visible */
+.deck__coin-dot { position: absolute; left: -1px; top: 14px; z-index: 0; width: 14px; height: 14px; border-radius: 50%; background: var(--yellow); border: 2px solid #cc991a; opacity: 0; }
+.deck__coin-text { font-family: var(--font-pixel); font-size: 0.8rem; letter-spacing: 1px; color: #4a4f5e; }
+
+/* ============================================================
+   Animation states (progressive enhancement)
+   - default: content visible (no JS / reduced motion)
+   - .about-armed (JS adds): screen "off", loading shown
+   - .about-started (JS adds on scroll-in): the sequence plays
+   ============================================================ */
+.about-armed .screen__body { opacity: 0; }
+.about-armed .screen__loading { display: flex; }
+.about-armed .screen__prompt { animation: about-blink 1s steps(1) infinite; }
+.about-armed .cabinet__screen { cursor: pointer; }
+.about-started .cabinet__screen { cursor: default; }
+
+/* sequence (plays on press): coin drops into slot -> pacman crosses -> power on */
+.about-started .deck__coin-dot { animation: about-coin-insert 0.9s ease-out both; }
+.about-started .screen__crosser { animation: about-cross 2s linear 1s forwards; }
+.about-started .screen__pellet { animation: about-eat 0.12s linear var(--eat, 0s) both; }
+.about-started .screen__loading { animation: about-fade-away 0.35s ease 3s forwards; }
+.about-started .screen__body { animation: about-power-on 0.6s ease 3.1s forwards; }
+.about-started .cabinet__screen { animation: about-crt 0.5s ease 3.1s; }
+
+@keyframes about-blink { 0%, 55% { opacity: 1; } 56%, 100% { opacity: 0.25; } }
+@keyframes about-coin-insert {
+    0% { transform: translateX(-30px); opacity: 0; }
+    20% { transform: translateX(-30px); opacity: 1; }
+    100% { transform: translateX(2px); opacity: 0; }
+}
+@keyframes about-cross { from { left: 5%; } to { left: 100%; } }
+@keyframes about-eat { to { opacity: 0; transform: translate(-50%, -50%) scale(0); } }
+@keyframes about-fade-away { to { opacity: 0; visibility: hidden; } }
+@keyframes about-power-on {
+    0% { opacity: 0; filter: brightness(2.2); }
+    35% { opacity: 1; filter: brightness(0.6); }
+    70% { filter: brightness(1.25); }
+    100% { opacity: 1; filter: brightness(1); }
+}
+@keyframes about-crt {
+    0% { filter: brightness(0.4); }
+    20% { filter: brightness(1.7); }
+    45% { filter: brightness(0.7); }
+    100% { filter: brightness(1); }
+}
+
+/* ---- responsive / motion ---- */
+@media (max-width: 860px) {
+    #about { display: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .about-armed .screen__body { opacity: 1; }
+    .about-armed .screen__loading { display: none; }
+    .about-started .deck__coin-dot,
+    .about-started .screen__crosser,
+    .about-started .screen__pellet,
+    .about-started .screen__loading,
+    .about-started .screen__body,
+    .about-started .cabinet__screen { animation: none; }
+}

--- a/css/maze.css
+++ b/css/maze.css
@@ -17,7 +17,7 @@
     content: "";
     position: absolute;
     inset: 22px;
-    border: 2.5px solid rgba(61, 90, 241, 0.4);
+    border: 2.5px solid rgba(102, 110, 128, 0.21);
     border-radius: 18px;
     pointer-events: none;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -170,10 +170,11 @@ button {
     --pac-size: 110px;
     width: var(--pac-size);
     height: var(--pac-size);
-    background: var(--yellow);
     border-radius: 50%;
-    /* circle with a wedge mouth cut out, facing right */
-    clip-path: polygon(50% 50%, 100% 32%, 100% 0, 0 0, 0 100%, 100% 100%, 100% 68%);
+    /* round body via border-radius; the wedge mouth (facing right) is a
+       transparent slice of a conic-gradient so the background shows through.
+       (a clip-path here would override border-radius and square the corners) */
+    background: conic-gradient(var(--yellow) 0 70deg, transparent 70deg 110deg, var(--yellow) 110deg 360deg);
     flex: none;
 }
 .pac-dot {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/maze.css" />
+    <link rel="stylesheet" href="css/about.css" />
 </head>
 <body>
     <!-- ===== Nav ===== -->
@@ -28,6 +29,7 @@
             <a href="#skills">Skills</a>
             <a href="#experience">Experience</a>
             <a href="#projects">Projects</a>
+            <a href="#about">About</a>
             <a href="#contact">Contact</a>
         </nav>
         <button class="nav__toggle" id="navToggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
@@ -225,11 +227,78 @@
             </div>
         </section>
 
+        <!-- ===== About (arcade player profile) ===== -->
+        <section id="about" class="section">
+            <div class="container">
+                <header class="section-head reveal">
+                    <p class="eyebrow">04 &mdash; About</p>
+                    <h2 class="section-title">Beyond the code</h2>
+                </header>
+                <div class="cabinet">
+                    <div class="cabinet__marquee">&mdash; ABOUT ME &mdash;</div>
+                    <div class="cabinet__monitor">
+                        <div class="cabinet__screen">
+                            <div class="screen__hud">
+                                <span class="screen__hud-l">1UP&nbsp;&nbsp;00</span>
+                                <span class="screen__hud-r">HI-SCORE</span>
+                            </div>
+                            <div class="screen__body">
+                                <div class="about__left">
+                                    <span class="pac about__avatar" aria-hidden="true"></span>
+                                    <h3 class="about__name">JAMIE KIM</h3>
+                                    <p class="about__blurb">Code is just one of my creative outlets &mdash; here are a few of the other ways I like to make things.</p>
+                                    <ul class="about__socials">
+                                        <li><a style="--c:var(--pink)" href="https://www.tiktok.com/@doyoojk" target="_blank" rel="noopener">TikTok</a></li>
+                                        <li><a style="--c:var(--orange)" href="https://www.instagram.com/do_.yu" target="_blank" rel="noopener">Instagram</a></li>
+                                        <li><a style="--c:var(--cyan)" href="https://github.com/doyoojk" target="_blank" rel="noopener">GitHub</a></li>
+                                        <li><a style="--c:var(--blue)" href="https://www.linkedin.com/in/jamiekimm/" target="_blank" rel="noopener">LinkedIn</a></li>
+                                    </ul>
+                                </div>
+                                <div class="about__right">
+                                    <p class="about__label">WHAT I CHASE</p>
+                                    <ul class="about__chase">
+                                        <li style="--gc:var(--red)"><span class="ghost"></span>Painting</li>
+                                        <li style="--gc:var(--pink)"><span class="ghost"></span>Photography</li>
+                                        <li style="--gc:var(--cyan)"><span class="ghost"></span>Cooking</li>
+                                        <li style="--gc:var(--orange)"><span class="ghost"></span>Beer</li>
+                                    </ul>
+                                    <p class="about__label">HI-SCORES</p>
+                                    <ul class="about__scores">
+                                        <li>KOR / ENG</li>
+                                        <li>Georgia Tech CS</li>
+                                        <li>Mario Kart champ</li>
+                                    </ul>
+                                    <a class="about__creative" href="https://www.tiktok.com/@doyoojk" target="_blank" rel="noopener">
+                                        <span class="about__creative-icon" aria-hidden="true"></span>
+                                        <span class="about__creative-text">
+                                            <span class="about__creative-title">CREATIVE MODE</span>
+                                            <span class="about__creative-sub">@doyoojk &middot; food on TikTok</span>
+                                        </span>
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="screen__loading" aria-hidden="true">
+                                <div class="screen__track">
+                                    <span class="pac screen__crosser"></span>
+                                </div>
+                                <p class="screen__prompt">PRESS START</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="cabinet__deck" aria-hidden="true">
+                        <span class="deck__joystick"><i class="deck__base"></i><i class="deck__stem"></i><i class="deck__ball"></i></span>
+                        <span class="deck__buttons"><i style="--b:var(--red)"></i><i style="--b:var(--yellow)"></i><i style="--b:var(--cyan)"></i></span>
+                        <span class="deck__coin"><i class="deck__coin-dot"></i><i class="deck__slot"></i><span class="deck__coin-text">INSERT COIN</span></span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- ===== Contact ===== -->
         <section id="contact" class="section">
             <div class="container">
                 <header class="section-head reveal">
-                    <p class="eyebrow">04 &mdash; Contact</p>
+                    <p class="eyebrow">05 &mdash; Contact</p>
                     <h2 class="section-title">Let&rsquo;s build something</h2>
                 </header>
                 <div class="contact-card reveal">

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
     initScrollSpy();
     initExperienceTabs();
     initReveal();
+    initAboutArcade();
     initCursorGlow();
 });
 
@@ -109,6 +110,59 @@ function initReveal() {
         { threshold: 0.01 }
     );
     items.forEach((el) => observer.observe(el));
+}
+
+/* ---- About arcade cabinet: arm on load, play the coin->cross->power-on
+   sequence when it scrolls into view (progressive enhancement) ---- */
+function initAboutArcade() {
+    const section = document.getElementById("about");
+    if (!section) return;
+    const screen = section.querySelector(".cabinet__screen");
+    if (!screen) return;
+    // reduced motion: leave the screen powered-on, no animation
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    section.classList.add("about-armed"); // screen "off"; PRESS START shown
+    screen.setAttribute("role", "button");
+    screen.setAttribute("tabindex", "0");
+    screen.setAttribute("aria-label", "Press start to power on the About screen");
+
+    // build the pellet trail; each pellet is "eaten" as the pacman reaches it.
+    // pacman crosses the track over CROSS_DUR starting at CROSS_DELAY (must match about.css)
+    const track = section.querySelector(".screen__track");
+    if (track) {
+        // pacman starts at START% (a little in from the edge, clear of the first
+        // pellet); pellets span FIRST%..LAST%. each pellet is eaten when the
+        // pacman's left reaches it. all percentages are of the track width.
+        const PELLETS = 10, CROSS_DELAY = 1, CROSS_DUR = 2, START = 5, FIRST = 14, LAST = 100;
+        for (let i = 0; i < PELLETS; i++) {
+            const f = i / (PELLETS - 1);
+            const pct = FIRST + f * (LAST - FIRST);
+            const pellet = document.createElement("span");
+            pellet.className = "screen__pellet";
+            pellet.style.left = `${pct}%`;
+            const eat = CROSS_DELAY + ((pct - START) / (100 - START)) * CROSS_DUR;
+            pellet.style.setProperty("--eat", `${eat.toFixed(2)}s`);
+            track.appendChild(pellet);
+        }
+    }
+
+    const start = () => {
+        section.classList.add("about-started"); // play coin -> pacman -> power-on
+        screen.removeAttribute("role");
+        screen.removeAttribute("tabindex");
+        screen.removeAttribute("aria-label");
+        screen.removeEventListener("click", start);
+        screen.removeEventListener("keydown", onKey);
+    };
+    const onKey = (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            start();
+        }
+    };
+    screen.addEventListener("click", start);
+    screen.addEventListener("keydown", onKey);
 }
 
 /* ---- soft pacman-yellow glow that follows the cursor ---- */


### PR DESCRIPTION
## What

A desktop-only **About me** section styled as an arcade machine.

- **Cabinet**: marquee header, monitor bezel/screen, and a control deck (tilted joystick, buttons, coin slot).
- **Press-to-start intro**: clicking the screen plays a sequence — coin inserts left-to-right into the slot, pacman crosses the screen eating the pellet trail, then the player-profile content powers on.
- **Profile content**: socials (TikTok / Instagram / GitHub / LinkedIn), the "what I chase" ghosts (Painting / Photography / Cooking / Beer), hi-score chips (KOR / ENG · Georgia Tech CS · Mario Kart champ), and a Creative Mode tile.
- Hidden on mobile for now; the whole sequence respects `prefers-reduced-motion` (content just shows, no animation).

## Drive-by fixes

- **Pacman shape, site-wide**: it was square-cornered because the `clip-path` overrode `border-radius`. Replaced with a real `border-radius` circle + a `conic-gradient` wedge mouth, so every pacman (hero, nav dot, maze, footer, About) is properly round.
- Matched the projects maze wall to the grey accent on mobile too.

## Notes

- New `css/about.css`; `initAboutArcade()` in `js/script.js` arms the screen and wires the press-to-start sequence (progressive enhancement — no JS / reduced motion leaves the content visible).