### PR TITLE
Docs: flesh out README + bring REDESIGN.md current

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# Jamie_Portfolio
-[Link to Portfolio](https://doyoojk.github.io/Jamie_Portfolio/)
+# Jamie Kim — Portfolio
+
+Personal portfolio site. **Live:** https://doyoojk.github.io/Jamie_Portfolio/
+
+A hand-built, dependency-free static site with a light "graph-paper grid" theme and
+Pac-Man accents throughout — including a projects gallery laid out as a Pac-Man maze and
+an About section styled as a playable arcade cabinet.
+
+## Tech
+
+- Vanilla **HTML / CSS / JS** — no framework, no build step.
+- Fonts via Google Fonts: **Pixelify Sans** (headings) + **Bitcount Prop Single** (arcade
+  accents) + **Quicksand** (body).
+- Hosted on **GitHub Pages**, deployed by GitHub Actions.
+
+## Sections
+
+`Hero · Skills · Experience · Projects · About · Contact`
+
+- **Projects** — a Pac-Man "maze" gallery: project rooms on a pellet trail with ghosts
+  between rows. Each room plays a short demo clip on hover. On mobile it becomes a vertical
+  "descend the maze" stack.
+- **About** — an arcade cabinet (desktop only for now). Press the screen and a coin slides
+  into the slot, Pac-Man crosses the screen eating the pellet trail, then a "player profile"
+  powers on (socials, hobbies as ghosts, hi-score chips). Respects `prefers-reduced-motion`.
+
+## Structure
+
+```
+index.html              # all markup
+css/
+  styles.css            # base theme, layout, grid background, Pac-Man accents
+  maze.css              # projects maze gallery
+  about.css             # About arcade cabinet
+js/
+  script.js             # nav, scroll-spy, reveals, About arcade sequence
+  projects.js           # renders project rooms from data/projects.json
+data/projects.json      # curated project list + media references
+assets/projects/        # project demo media (mp4 / image)
+scripts/                # media helpers (fetch + optimize, require ffmpeg)
+.github/workflows/      # GitHub Pages deploy
+```
+
+## Run locally
+
+No build step — serve the folder over HTTP:
+
+```bash
+python3 -m http.server 8000
+# then open http://127.0.0.1:8000/
+```
+
+## Projects & media
+
+Project cards are data-driven from `data/projects.json` (title, tag, links, and a media
+file). Demo clips live in `assets/projects/` as `mp4` (with an image fallback); the renderer
+prefers a `<video>` and falls back to an image. `scripts/optimize-media.py` converts source
+GIFs/clips to compact mp4 (needs `ffmpeg`).
+
+## Deploy
+
+Pushing to `main` triggers `.github/workflows/static.yml`, which publishes the site to
+GitHub Pages. No manual step required.

--- a/REDESIGN.md
+++ b/REDESIGN.md
@@ -1,11 +1,13 @@
 # Portfolio Redesign — Context & Progress
 
-Working context for the v1 redesign of this portfolio. Living doc — update as we go.
+Working context for the v2 redesign of this portfolio. Living doc — update as we go.
 
 ## Goal
-Modernize the portfolio: clean/simple, smoother animations, fully responsive. Move from the
-dark gradient + busy pacman-maze background to a **light graph-paper grid** with pacman kept
-only as tasteful **accents**. Projects get a creative **pacman-maze gallery** treatment.
+Modernize the portfolio: clean/simple, smoother animations, fully responsive. Moved from the
+old dark gradient + busy pacman-maze background to a **light graph-paper grid** with Pac-Man
+kept as tasteful **accents**. Projects get a creative **Pac-Man maze gallery** treatment.
+
+**Status: v2 is shipped and live** at https://doyoojk.github.io/Jamie_Portfolio/.
 
 ## Design source (Figma)
 - File: `https://www.figma.com/design/VDgh8HjZYsWgP8zErSbtPz/Untitled`
@@ -14,37 +16,52 @@ only as tasteful **accents**. Projects get a creative **pacman-maze gallery** tr
 - Built via Figma MCP on the personal account (doyoojk@gmail.com, upgraded to Pro). The
   loop.com account can't edit this file.
 
-## Design decisions (locked for v1)
+## Design decisions
 - **Background:** light grey graph-paper grid (`#F6F7F9` bg, `#E2E6EC` lines, 48px).
-- **Accents / palette:** pacman yellow `#FFC233`; ghost colors cyan `#14C7C7`, pink `#FF5FA2`,
-  orange `#FF9F43`, red `#FF5B5B`; maze-wall blue `#3D5AF1`; violet `#8B5CF6` (creative).
-- **Type:** Pixelify Sans (headings/accents) + Quicksand (body) in the mockup.
-  - NOTE: user wants a dotty/LED font (**Bitcount Prop Single**, fallback Doto). Figma can't
-    render those (too new), but they load fine via Google Fonts CDN in code. Finalize in code.
-- **Sections:** Nav · Hero · Skills · Experience · Projects (maze) · Contact · Footer.
-- **Content is resume-accurate** (see `~/Downloads/main.md`): Walmart SWE II, etc.
-  - Skills = Languages, Frontend, Backend & Frameworks, Testing & CI/CD, Automation & Tools,
-    Cloud Platforms, + featured **Creative & Media** (Processing, p5.js, Three.js, Figma,
-    Photoshop, video editing).
+- **Accents / palette:** Pac-Man yellow `#FFC233`; ghost colors cyan `#14C7C7`, pink `#FF5FA2`,
+  orange `#FF9F43`, red `#FF5B5B`; violet `#8B5CF6` (creative). The maze wall now uses a subtle
+  grey accent (`rgba(102,110,128,0.21)`) instead of the original blue.
+- **Type:** Pixelify Sans (headings) + **Bitcount Prop Single** (arcade/LED accents) +
+  Quicksand (body), all via Google Fonts. (Figma can't render Bitcount, so it was finalized in
+  code.)
+- **Sections:** Nav · Hero · Skills · Experience · Projects (maze) · About (arcade) · Contact.
+- **Content is resume-accurate** (Walmart SWE II, etc.). Skills = Languages, Frontend, Backend &
+  Frameworks, Testing & CI/CD, Automation & Tools, Cloud Platforms, + a featured **Creative &
+  Media** card (Processing, p5.js, Three.js, Figma, Photoshop, video editing).
 - **Projects featured (6 visual):** Emotion Detection Art, Animated Kitty, Virtual Space Sim,
-  Loop Subdivision, Cat-Fall, ATL Path-Finder.
-- **Mobile:** compact (smaller type ~0.85, ~30px margins); projects = zigzag mini-maze (small
-  rooms alternating across a pellet trail, pacman + ghost).
+  Loop Subdivision, Cat-Fall, ATL Path-Finder. Data-driven from `data/projects.json`; demos are
+  local `mp4` (with image fallback), no more GitHub README scraping.
+
+## Pac-Man maze gallery (projects)
+- **Desktop:** 3×2 board of project "rooms" on a pellet trail, with Pac-Man + ghosts between
+  rows, inside a maze wall.
+- **Mobile:** vertical "descend the maze" stack — rooms centered, Pac-Man down the top, pellet
+  and ghost connectors between cards.
+
+## About — arcade cabinet
+- An "About me" section styled as a playable arcade machine: cabinet with marquee, monitor
+  bezel/screen, and a control deck (tilted joystick, buttons, coin slot).
+- **Press-to-start intro:** clicking the screen plays a coin sliding into the slot →
+  Pac-Man crossing the screen eating a pellet trail → the "player profile" powers on (socials,
+  hobbies as ghosts, hi-score chips, a Creative Mode tile). Respects `prefers-reduced-motion`.
+- **Desktop only for now** (`#about` is hidden under 860px).
 
 ## Status
 - [x] Desktop + mobile mockups (Figma)
-- [x] **v2 shipped in code** (PR #2, merged): light grid theme, pacman maze gallery, Bitcount
-      Prop Single font, curated `data/projects.json` + local GIFs (no more GitHub README
-      scraping), resume-accurate Skills/Experience, fluid/responsive layout.
-- [x] Deploy hotfix (PR #3, merged): `js/projects.js` was gitignored → 404 on the live site.
+- [x] **v2 shipped** (PR #2): light grid theme, Pac-Man maze gallery, Bitcount Prop Single font,
+      curated `data/projects.json`, resume-accurate Skills/Experience, fluid/responsive layout.
+- [x] Deploy 404 hotfix (PR #3): `js/projects.js` was gitignored.
+- [x] Mobile layout (PR #4): vertical descending maze + compact sizing; fixed the closed
+      mobile-menu swallowing taps near the top.
+- [x] Pages deploy workflow cleanup (PR #6): removed the steps that regenerated/committed the
+      obsolete `repos.json`.
+- [x] Media optimization (PR #7): project GIFs → mp4 (~19MB → ~2.6MB) via
+      `scripts/optimize-media.py`.
+- [x] **About arcade section** (PR #8): cabinet + press-to-start coin/Pac-Man intro; also fixed
+      the Pac-Man shape site-wide (was square-cornered — `clip-path` overrode `border-radius`;
+      now a `border-radius` circle with a `conic-gradient` wedge mouth).
 
 ## TODO
-- [ ] **Clean up the Pages deploy workflow** (`.github/workflows/static.yml`): remove the leftover
-      v1 steps (*Setup Node.js*, *Fetch GitHub repos*, *Commit data*) that regenerate and
-      re-commit the obsolete `repos.json` on every deploy, drop the `contents: write` permission,
-      and delete `repos.json`. Requires a token with `workflow` scope (`gh auth refresh -s workflow`).
-- [ ] **Mobile layout** (in progress — branch `feat/mobile-layout`): zigzag mini-maze for the
-      projects section + compact mobile sizing. Also carries the closed-mobile-menu tap-interception
-      fix (the menu kept `display:flex` and swallowed taps near the top of the page).
-- [ ] Media optimization: convert project GIFs → mp4/webm to shrink the ~19MB payload
-      (`scripts/optimize-media.py`, needs `ffmpeg`).
+- [ ] **Mobile About layout** — the arcade cabinet is desktop-only; design a compact mobile
+      version (currently hidden under 860px).
+- [ ] Minor: the Emotion Detection Art poster (first video frame) is a bit dark.


### PR DESCRIPTION
Documentation only — no site/code changes.

- **README.md**: replace the one-line stub with a real overview — what the site is + live link, tech stack, sections (maze projects gallery, arcade About), repo structure, how to run locally, project media notes, and deploy.
- **REDESIGN.md**: bring the living doc current — mark the shipped milestones (PRs #2–#8) done, document the Pac-Man maze gallery and the arcade About section, and trim the TODO list down to the mobile About layout (plus a minor poster note).

Note: the README change was originally committed to `feat/about-section` just after PR #8 merged, so it didn't make it into `main`. This PR carries it over (off the latest `main`) along with the REDESIGN.md update.